### PR TITLE
ENH: Add --cache-id command line option

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,11 @@ Standard Options:
     More than one pattern to be ignored can be specified by repeating this option with other regex
     value to ignore
 
+  --cache-id                       [default: null]
+
+    If you're running multiple persistify instances from the same directory, use this to
+    differentiate them.
+
 ```
 
 ## Examples

--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -18,8 +18,10 @@ function run() {
   var watch = persistifyArgs.watch;
   var recreate = persistifyArgs.recreate;
   var neverCache = persistifyArgs[ 'never-cache' ];
+  var cacheId = persistifyArgs['cache-id'];
 
   var w = require( '../' )( null, {
+    cacheId: cacheId,
     command: _argv.join( ' ' ),
     neverCache: neverCache,
     watch: watch,


### PR DESCRIPTION
I persistify multiple bundles from the same folder (in parallel), at the moment they try and share the same cache which doesn't work so well; this allows me to fix that.
