### PR TITLE
handle multi-item neverCache arrays

### DIFF
--- a/index.js
+++ b/index.js
@@ -73,7 +73,7 @@ module.exports = function ( browserifyOpts, opts, argv ) {
       }
       cachedFiles.forEach( function ( file ) {
         for (var i = 0; i < neverCache.length; i++) {
-          var regex = parseAsRegex( neverCache[ 0 ] );
+          var regex = parseAsRegex( neverCache[ i ] );
 
           if ( file.match( regex ) ) {
             b.emit( 'skip:cache', file );


### PR DESCRIPTION
Only the first item in the neverCache array is currently used.

for example `.template` files are currently getting cached

```
neverCache: [ /\.less$/, /\.template/ ],
```
