### PR TITLE
updated dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "simplessy": "^1.0.2"
   },
   "dependencies": {
-    "browserify": "^12.0.1",
+    "browserify": "^14.4.0",
     "file-entry-cache": "^1.2.0",
     "flat-cache": "^1.2.1",
     "hash-string": "^1.0.0",
@@ -55,7 +55,7 @@
     "outpipe": "^1.1.1",
     "subarg": "^1.0.0",
     "through2": "^2.0.0",
-    "watchify": "^3.6.1",
+    "watchify": "^3.9.0",
     "xtend": "^4.0.0"
   },
   "changelogx": {


### PR DESCRIPTION
updated to latest version of browserify and watchify
I tested it and seems to keep working

I tried using peerDependencies setting both to "*". It worked, but I'm not sure if that's the best solution since then it would require the user to make sure he has installed browserify/watchify or else persistify would crash without them.