### PR TITLE
ignore watch passed to watchify

### DIFF
--- a/index.js
+++ b/index.js
@@ -117,7 +117,7 @@ module.exports = function ( browserifyOpts, opts, argv ) {
 
   if ( opts.watch ) {
     b = watchify( b, {
-      ignoreWatch: b.argv['ignore-watch'] || b.argv.iw
+      ignoreWatch: b.argv[ "ignore-watch" ] || b.argv.iw
     } );
   }
 

--- a/index.js
+++ b/index.js
@@ -116,7 +116,9 @@ module.exports = function ( browserifyOpts, opts, argv ) {
   }
 
   if ( opts.watch ) {
-    b = watchify( b );
+    b = watchify( b, {
+      ignoreWatch: b.argv['ignore-watch'] || b.argv.iw
+    } );
   }
 
   collect();


### PR DESCRIPTION
stolen from: https://github.com/browserify/watchify/blob/master/bin/args.js#L10-L13

If you apply `--ignore-watch` watchify won't be watching the pattern you pass (or `node_modules` by default) which ends up in huge speedup.