### PR TITLE
use browserify and watchify as peer and dev depedency

### DIFF
--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -114,4 +114,13 @@ function run() {
   bundle();
 }
 
+try {
+  require.resolve( "browserify" );
+  require.resolve( "watchify" );
+} catch (x) {
+  // eslint-disable-next-line no-console
+  console.error( "browserify and watchify are mandatory, please install those!" );
+  process.exit(1);
+}
+
 run();

--- a/package.json
+++ b/package.json
@@ -38,16 +38,17 @@
   ],
   "devDependencies": {
     "babelify": "^6.1.3",
+    "browserify": "^16.1.1",
     "changelogx": "^1.0.18",
     "esbeautifier": "^6.1.8",
     "eslinter": "^3.2.1",
     "precommit": "^1.1.5",
     "prepush": "^3.1.4",
     "react": "^0.13.3",
-    "simplessy": "^1.0.2"
+    "simplessy": "^1.0.2",
+    "watchify": "^3.11.0"
   },
   "dependencies": {
-    "browserify": "^12.0.1",
     "file-entry-cache": "^1.2.0",
     "flat-cache": "^1.2.1",
     "hash-string": "^1.0.0",
@@ -55,8 +56,11 @@
     "outpipe": "^1.1.1",
     "subarg": "^1.0.0",
     "through2": "^2.0.0",
-    "watchify": "^3.6.1",
     "xtend": "^4.0.0"
+  },
+  "peerDependencies": {
+    "browserify": "^16.1.1",
+    "watchify": "^3.11.0"
   },
   "changelogx": {
     "ignoreRegExp": [


### PR DESCRIPTION
I saw the discussion in https://github.com/royriojas/persistify/pull/14 so I did this pr.

To notify the users we could add the following snippet to the `bin/cmd.js`:

```diff
+try {
+  require.resolve('browserify');
+} catch (x) {
+  console.error('browserify is not install, run npm install browserify');
+  process.exit(1);
+}
run();
```